### PR TITLE
added update_A! function

### DIFF
--- a/src/QDLDL.jl
+++ b/src/QDLDL.jl
@@ -1,6 +1,6 @@
 module QDLDL
 
-export qdldl, \, solve, solve!, update_diagonal!, positive_inertia
+export qdldl, \, solve, solve!, update_diagonal!, positive_inertia, update_A!
 
 using AMD, SparseArrays
 using LinearAlgebra: istriu, triu, Diagonal
@@ -34,6 +34,12 @@ struct QDLDLWorkspace{Tf<:AbstractFloat,Ti<:Integer}
 
     #The upper triangular matrix factorisation target
     triuA::SparseMatrixCSC{Tf,Ti}
+
+    # permute_symmetric! workspace vectors
+    Pr::Vector{Ti}
+    Pc::Vector{Ti}
+    Pv::Vector{Tf}
+    num_entries::Vector{Ti}
 end
 
 function QDLDLWorkspace(triuA::SparseMatrixCSC{Tf,Ti}) where {Tf<:AbstractFloat,Ti<:Integer}
@@ -67,7 +73,13 @@ function QDLDLWorkspace(triuA::SparseMatrixCSC{Tf,Ti}) where {Tf<:AbstractFloat,
     #start since we haven't counted anything yet
     positive_inertia = Base.RefValue{Ti}(-1)
 
-    QDLDLWorkspace(etree,Lnz,iwork,bwork,fwork,Ln,Lp,Li,Lx,D,Dinv,positive_inertia,triuA)
+    # permute_symmetric! workspace vectors
+    Pr = zeros(Ti, nnz(triuA))
+    Pc = zeros(Ti, Ln + 1)
+    Pv = zeros(Tf, nnz(triuA))
+    num_entries = zeros(Ti, Ln)
+
+    QDLDLWorkspace(etree,Lnz,iwork,bwork,fwork,Ln,Lp,Li,Lx,D,Dinv,positive_inertia,triuA,Pr,Pc,Pv,num_entries)
 
 end
 
@@ -107,7 +119,7 @@ function qdldl(A::SparseMatrixCSC{Tv,Ti};
 
     #permute using symperm, producing a triu matrix to factor
     if perm != nothing
-        A = permute_symmetric(A, iperm)  #returns an upper triangular matrix
+        A = permute_symmetric!(A, iperm)  #returns an upper triangular matrix
     else
         if(!istriu(A))
             A = triu(A);
@@ -502,8 +514,7 @@ end
 
 
 "Given a sparse symmetric matrix `A` (with only upper triangular entries), return permuted sparse symmetric matrix `P` (only upper triangular) given the inverse permutation vector `iperm`."
-function permute_symmetric(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti}, Pr::AbstractVector{Ti} = zeros(Ti, nnz(A)), Pc::AbstractVector{Ti} = zeros(Ti, size(A, 1) + 1), Pv::AbstractVector{Tv} = zeros(Tv, nnz(A)) ) where {Tv <: AbstractFloat, Ti <: Integer}
-
+function permute_symmetric!(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti}, Pr::AbstractVector{Ti} = zeros(Ti, nnz(A)), Pc::AbstractVector{Ti} = zeros(Ti, size(A, 1) + 1), Pv::AbstractVector{Tv} = zeros(Tv, nnz(A)), num_entries::AbstractVector{Ti} = zeros(Ti,size(A,2)) ) where {Tv <: AbstractFloat, Ti <: Integer}
     # perform a number of argument checks
     m, n = size(A)
     m != n && throw(DimensionMismatch("Matrix A must be sparse and square"))
@@ -513,15 +524,17 @@ function permute_symmetric(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti}
     if n != length(iperm)
         throw(DimensionMismatch("Dimensions of sparse matrix A must equal the length of iperm, $((m,n)) != $(iperm)"))
     end
-    return _permute_symmetric(A, iperm, Pr, Pc, Pv)
+    return _permute_symmetric!(A, iperm, Pr, Pc, Pv, num_entries)
 end
 
 # the main function without extra argument checks
 # following the book: Timothy Davis - Direct Methods for Sparse Linear Systems
-function _permute_symmetric(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti}, Pr::AbstractVector{Ti}, Pc::AbstractVector{Ti}, Pv::AbstractVector{Tv}) where {Tv <: AbstractFloat, Ti <: Integer}
+function _permute_symmetric!(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti}, Pr::AbstractVector{Ti}, Pc::AbstractVector{Ti}, Pv::AbstractVector{Tv}, num_entries::AbstractVector{Ti}) where {Tv <: AbstractFloat, Ti <: Integer}
     # 1. count number of entries that each column of P will have
     n = size(A, 2)
-    num_entries = zeros(Ti, n)
+
+    # zero out num_entries
+    num_entries .= 0
     Ar = A.rowval
     Ac = A.colptr
     Av = A.nzval
@@ -580,5 +593,11 @@ function _permute_symmetric(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti
     return (P')'
 end
 
+function update_A!(F::QDLDLFactorisation,A::SparseMatrixCSC{Tv, Ti}) where {Tv <: AbstractFloat, Ti <: Integer}
+    # update the factorization object F with a new A of the same sparsity pattern
+    F.workspace.triuA .= _permute_symmetric!(A,F.iperm,F.workspace.Pr,F.workspace.Pc,F.workspace.Pv,F.workspace.num_entries)
+    factor!(F.workspace,F.logical)
+    return nothing
+end
 
 end #end module

--- a/test/UnitTests/update_matrix.jl
+++ b/test/UnitTests/update_matrix.jl
@@ -1,0 +1,32 @@
+using Test, LinearAlgebra, SparseArrays, Random
+using QDLDL
+rng = Random.MersenneTwister(2401)
+
+@testset "matrix update checks" begin
+
+  # random KKT system
+  m = 20
+  n = 30
+  Q = random_psd(n)
+  G = sprandn(rng, m, n, 0.3)
+  A1,b1 = build_kkt(Q, G)
+
+  # create factorisation
+  F = qdldl(A1)
+
+  # compare qdldl solve to \
+  @test norm(F\b1 - A1\b1) < 1e-10
+
+  # update kkt with new data in the same sparsity pattern
+  Q2 = copy(Q)
+  Q2.nzval .= randn(rng, nnz(Q2))
+  Q2 = Q2' + Q2
+  G2 = copy(G)
+  G2.nzval .= randn(rng, nnz(G2))
+  A2,b2 = build_kkt(Q2, G2)
+
+  # update factorisation in-place and test solution
+  update_A!(F,A2)
+  @test norm(F\b2 - A2\b2) < 1e-10
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,17 @@ function random_psd(n)
 
 end
 
+function build_kkt(Q,G)
+  n = size(Q,1)
+  m = size(G,1)
+
+  A = [Q G';G zeros(m,m)] + 1e-2*Diagonal([ones(n);-ones(m)])
+  A = sparse(A)
+
+  b = randn(rng, n + m)
+
+  return A,b
+end
 
 @testset "All Unit Tests" begin
 
@@ -16,6 +27,7 @@ end
   include("./UnitTests/refactoring.jl")
   include("./UnitTests/non-quasidef.jl")
   include("./UnitTests/inertia.jl")
+  include("./UnitTests/update_matrix.jl")
 
 end
 nothing


### PR DESCRIPTION
`update_A!` allows for an allocation-free in-place factorization of a new A matrix with the same sparsity pattern as what the QDLDLfactorisation struct was created with.  The permutation is unchanged between the old and new matrices. 

```
# create QDLDL instance
F = qdldl(A)

# update the matrix and corresponding factorization for A2
update_A!(F,A2)
```