### PR TITLE
Fix for SparseArray constructor change in Julia 1.7

### DIFF
--- a/src/QDLDL.jl
+++ b/src/QDLDL.jl
@@ -575,7 +575,8 @@ function _permute_symmetric(A::SparseMatrixCSC{Tv, Ti}, iperm::AbstractVector{Ti
             end
         end
     end
-    P = SparseMatrixCSC{Tv, Ti}(n, n, Pc, Pr, Pv)
+    nz_new = Pc[end] - 1
+    P = SparseMatrixCSC{Tv, Ti}(n, n, Pc, Pr[1:nz_new], Pv[1:nz_new])
     # order row indices within P.rowcal[P.colptr[k]:P.colptr[k+1]-1]
     return (P')'
 end


### PR DESCRIPTION
This fixes an error that popped in in Julia 1.7, which added the [`_goodbuffers`](https://github.com/JuliaLang/julia/blob/4f1ff0bb0055806fcce880765c0be26313f936bf/stdlib/SparseArrays/src/sparsematrix.jl#L86) check. The previous version wasn't trimming the nonzero entries for the lower triangular portion of the matrix, so the `Pr` and `Pv` vectors were longer than expected.