### PR TITLE
Run CI on all supported Julia versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: '1.5'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1.5'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1.5'
-            os: windows-latest
-            arch: x64
+        version: ['1.6', '1', 'nightly']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        arch: [x64]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
This updates the CI to run on the three different Julia versions supported: the LTS 1.6, the current stable version (1.7), and the nightly version.